### PR TITLE
title name changed from website to horiseon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="./assets/css/style.css">
-    <title>website</title>
+    <title>Horiseon</title>
 </head>
 
 <body>


### PR DESCRIPTION
Title name changed from website to horiseon. The previous title name was not concise and too generic. The title was changed to the site name to make it more accessible especially when users have multiple sites open. the previous name website was too vague and had no specific association to the company name.